### PR TITLE
Fix compile errors in API key placeholders

### DIFF
--- a/book_edit_test.ipynb
+++ b/book_edit_test.ipynb
@@ -1,0 +1,35 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "df8796fc",
+   "metadata": {},
+   "source": [
+    "# Book Editing Test\n",
+    "\n",
+    "This is a sample notebook for testing book editing capabilities."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "028c2bfd",
+   "metadata": {},
+   "source": [
+    "Use this notebook to experiment with changes in the Jupyter Book."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cff976fe",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"Hello, book editing!\")"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/edit_toc.py
+++ b/edit_toc.py
@@ -3,8 +3,10 @@ import yaml
 import requests
 
 
-# Set your OpenAI API key here
-api_key = 
+# Set your OpenAI API key here. The script will use this key when making
+# requests to the OpenAI API. Replace the empty string with your actual key or
+# set the OPENAI_API_KEY environment variable and modify the code accordingly.
+api_key = ""
 
 def load_toc(file_path):
     with open(file_path, 'r') as file:

--- a/export_code.py
+++ b/export_code.py
@@ -1,7 +1,8 @@
 import os
 
-# Set the environment variable
-os.environ['OPENAI_API_KEY'] = 
+# Set the environment variable with your OpenAI API key. Replace the empty
+# string with your actual key if you want this script to set it for you.
+os.environ['OPENAI_API_KEY'] = ""
 
 # Retrieve the value of the environment variable
 api_key = os.environ['OPENAI_API_KEY']

--- a/generate_content.py
+++ b/generate_content.py
@@ -6,8 +6,9 @@ from nbformat.v4 import new_markdown_cell, new_code_cell, new_notebook
 def generate_content(yaml_content):
     # Load the YAML content
     toc = yaml.load(yaml_content, Loader=yaml.SafeLoader)
-    # Define the API key
-    api_key = 
+    # Define the API key. Replace the empty string with your actual key or
+    # configure the OPENAI_API_KEY environment variable as needed.
+    api_key = ""
 
     # Set the API key for the OpenAI library
     openai.api_key = api_key

--- a/generate_toc.py
+++ b/generate_toc.py
@@ -3,8 +3,9 @@ import openai
 import re
 import requests
 
-# Define the API key
-api_key = 
+# Define the API key. Replace the empty string with your actual key if you
+# want to use this script directly.
+api_key = ""
 
 # Set the API key for the OpenAI library
 openai.api_key = api_key


### PR DESCRIPTION
## Summary
- assign empty string placeholders for OpenAI API key values in scripts
- allow `python -m py_compile` to run successfully

## Testing
- `python -m py_compile *.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6856bbb7ef9483219e446823a195b2ce